### PR TITLE
Add code16/32/64 support to x86/64 dis/assembler

### DIFF
--- a/src/libs/Assembler.php
+++ b/src/libs/Assembler.php
@@ -84,7 +84,8 @@ class Assembler
         //  - ". " allows for relative jumps, e.g. jmp . + 5
         $safe_directives = array(
             ".ascii", ".asciz", ".align", ".balign",
-            ".byte", ".int", ".double", ".quad", ".octa", ".word", ". "
+            ".byte", ".int", ".double", ".quad", ".octa", ".word", ". ",
+            ".code16", ".code32", ".code64"
         );
 
         foreach ($safe_directives as $directive)


### PR DESCRIPTION
This allows for assembling 16-bit code, protected mode, and long mode code in the same file